### PR TITLE
use anonymous, not named, type constraints for one-offs

### DIFF
--- a/lib/Dist/Zilla/Plugin/Git/Check.pm
+++ b/lib/Dist/Zilla/Plugin/Git/Check.pm
@@ -9,13 +9,13 @@ use Moose;
 use namespace::autoclean 0.09;
 use Moose::Util::TypeConstraints qw(enum);
 
-enum('DieWarnIgnore', [qw[ die warn ignore ]]);
+use constant DieWarnIgnore => do { enum [qw[ die warn ignore ]] };
 
 with 'Dist::Zilla::Role::BeforeRelease';
 with 'Dist::Zilla::Role::Git::Repo';
 with 'Dist::Zilla::Role::Git::DirtyFiles';
 
-has untracked_files => ( is=>'ro', isa=>'DieWarnIgnore', default => 'die' );
+has untracked_files => ( is=>'ro', isa => DieWarnIgnore, default => 'die' );
 
 # -- public methods
 

--- a/lib/Dist/Zilla/Plugin/Git/NextVersion.pm
+++ b/lib/Dist/Zilla/Plugin/Git/NextVersion.pm
@@ -24,10 +24,13 @@ with 'Dist::Zilla::Role::Git::Repo';
 
 # -- attributes
 
-subtype 'CoercedRegexp', as 'RegexpRef';
-coerce 'CoercedRegexp', from 'Str', via { qr/$_/ };
+use constant CoercedRegexp => do {
+    my $tc = subtype as 'RegexpRef';
+    coerce $tc, from 'Str', via { qr/$_/ };
+    $tc;
+};
 
-has version_regexp  => ( is => 'ro', isa=>'CoercedRegexp', coerce => 1,
+has version_regexp  => ( is => 'ro', isa=> CoercedRegexp, coerce => 1,
                          default => sub { qr/^v(.+)$/ } );
 
 has first_version  => ( is => 'ro', isa=>'Str', default => '0.001' );


### PR DESCRIPTION
By their nature, named type constraints are global.  This means that it's
particularly important to choose names not likely to conflcit with any other
type name someone defined somewhere else (and is one of the primary reasons
for the existance of MooseX::Types).

For our purposes, it's enough to create anonymous types, that are then
referenced by 'constants' used during attribute definition.  This gives us the
type constraint/coercions we need without the risk of a potential (painful and
confusing debug session somewhere down the line :)
