### PR TITLE
Specify a minimum Test::Fatal version

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -13,6 +13,9 @@ x_MailingList = http://www.listbox.com/subscribe/?list_id=139292
 directory = corpus
 directory = t
 
+[Prereqs]
+Test::Fatal = 0.010
+
 [Bootstrap::lib]
 [@Author::JQUELIN]
 :version = 3.000 ; need TestRelease


### PR DESCRIPTION
This is required because older Test::Fatal's (i.e. 0.003) do not have lives_ok() .
