### PR TITLE
Restore CWD at END { } to repress warnings ( and the problem they're war...

### DIFF
--- a/t/check.t
+++ b/t/check.t
@@ -10,8 +10,11 @@ use File::pushd qw{ pushd };
 use Git::Wrapper;
 use Test::More 0.88 tests => 50; # done_testing
 use Test::Fatal 0.006 qw( lives_ok );
-
+use Cwd qw(cwd);
 use t::Util qw( throws_ok );
+
+my $cwd = cwd();
+END { chdir $cwd };
 
 # Mock HOME to avoid ~/.gitexcludes from causing problems
 $ENV{HOME} = tempdir( CLEANUP => 1 );

--- a/t/commit-build-custom.t
+++ b/t/commit-build-custom.t
@@ -15,6 +15,7 @@ use Cwd qw(cwd);
 $ENV{HOME} = tempdir( CLEANUP => 1 );
 
 my $cwd = cwd();
+END { chdir $cwd }
 my $zilla = Dist::Zilla::Tester->from_config({
   dist_root => dir('corpus/commit-build-custom')->absolute,
 });

--- a/t/commit-build-src-as-parent.t
+++ b/t/commit-build-src-as-parent.t
@@ -18,6 +18,7 @@ $ENV{HOME} = tempdir( CLEANUP => 1 );
 my $corpus_dir = dir('corpus/commit-build-src-as-parent')->absolute;
 
 my $cwd = cwd();
+END { chdir $cwd };
 my $zilla = Dist::Zilla::Tester->from_config({ dist_root => $corpus_dir, });
 
 # build fake repository

--- a/t/commit-build.t
+++ b/t/commit-build.t
@@ -15,6 +15,7 @@ use Cwd qw(cwd);
 $ENV{HOME} = tempdir( CLEANUP => 1 );
 
 my $cwd = cwd();
+END { chdir $cwd }
 my $zilla = Dist::Zilla::Tester->from_config({
   dist_root => dir('corpus/commit-build')->absolute,
 });

--- a/t/commit-dirtydir.t
+++ b/t/commit-dirtydir.t
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 
+use Cwd qw( cwd );
 use Dist::Zilla  1.093250;
 use Dist::Zilla::Tester;
 use Git::Wrapper;
@@ -13,6 +14,8 @@ use Test::More   tests => 3;
 
 # Mock HOME to avoid ~/.gitexcludes from causing problems
 $ENV{HOME} = tempdir( CLEANUP => 1 );
+my $cwd = cwd();
+END { chdir $cwd }
 
 # build fake repository
 my $zilla = Dist::Zilla::Tester->from_config({

--- a/t/commit-ws.t
+++ b/t/commit-ws.t
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 
+use Cwd qw( cwd );
 use Dist::Zilla  1.093250;
 use Dist::Zilla::Tester;
 use File::Temp qw{ tempdir };
@@ -12,6 +13,9 @@ use Test::More   tests => 1;
 
 # Mock HOME to avoid ~/.gitexcludes from causing problems
 $ENV{HOME} = tempdir( CLEANUP => 1 );
+
+my $cwd = cwd();
+END { chdir $cwd }
 
 my $zilla = Dist::Zilla::Tester->from_config({
   dist_root => dir('corpus/commit-ws')->absolute,

--- a/t/commit.t
+++ b/t/commit.t
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 
+use Cwd qw( cwd );
 use Dist::Zilla  1.093250;
 use Dist::Zilla::Tester;
 use File::Temp qw{ tempdir };
@@ -12,6 +13,8 @@ use Test::More   tests => 1;
 
 # Mock HOME to avoid ~/.gitexcludes from causing problems
 $ENV{HOME} = tempdir( CLEANUP => 1 );
+my $cwd = cwd();
+END { chdir $cwd }
 
 # build fake repository
 my $zilla = Dist::Zilla::Tester->from_config({

--- a/t/repo-dir.t
+++ b/t/repo-dir.t
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 
+use Cwd qw( cwd );
 use Dist::Zilla  1.093250;
 use Dist::Zilla::Tester;
 use File::Temp qw{ tempdir };
@@ -13,6 +14,8 @@ use Test::More   tests => 1;
 
 # Mock HOME to avoid ~/.gitexcludes from causing problems
 $ENV{HOME} = tempdir( CLEANUP => 1 );
+my $cwd = cwd();
+END { chdir $cwd }
 
 # build fake repository
 my $zilla = Dist::Zilla::Tester->from_config({

--- a/t/tag-signed.t
+++ b/t/tag-signed.t
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 
+use Cwd qw( cwd );
 use Dist::Zilla  1.093250;
 use Dist::Zilla::Tester;
 use File::Copy qw{ cp };
@@ -19,6 +20,10 @@ which('gpg')
 
 # Mock HOME to avoid ~/.gitexcludes from causing problems
 $ENV{HOME} = $ENV{GNUPGHOME} = tempdir( CLEANUP => 1 );
+
+my $cwd = cwd();
+END { chdir $cwd }
+
 delete $ENV{GIT_COMMITTER_NAME};
 delete $ENV{GIT_COMMITTER_EMAIL};
 cp 'corpus/dzp-git.pub', "$ENV{GNUPGHOME}/pubring.gpg";

--- a/t/tag.t
+++ b/t/tag.t
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 
+use Cwd qw( cwd );
 use Dist::Zilla  1.093250;
 use Dist::Zilla::Tester;
 use File::Temp qw{ tempdir };
@@ -12,7 +13,8 @@ use Test::More   tests => 4;
 
 # Mock HOME to avoid ~/.gitexcludes from causing problems
 $ENV{HOME} = tempdir( CLEANUP => 1 );
-
+my $cwd = cwd();
+END { chdir $cwd }
 # build fake repository
 my $zilla = Dist::Zilla::Tester->from_config({
   dist_root => dir('corpus/tag')->absolute,


### PR DESCRIPTION
...ning about ) about 'cant remove path when cwd is X/Y for X'

Without this patch, you might notice that after doing 

```
prove -lvr t/
```

that you have a dir `tmp/` with lots of tempdirs inside that, which haven't been GC'd 
