### PR TITLE
Topic/gatherdir exclude filename

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Dist::Zilla::Plugin::Git
 
 {{$NEXT}}
+ - fix exclude_filename to not match partial paths (Karen Etheridge)
 
 2.015     2013-07-06 21:14:09 Europe/Paris
  - bail out of Build.PL unless git 1.5.4 or later is found (christopher madsen)

--- a/t/gatherdir.t
+++ b/t/gatherdir.t
@@ -9,7 +9,7 @@ use File::pushd;
 use File::Temp qw{ tempdir };
 use Git::Wrapper;
 use Path::Class;
-use Test::More      tests => 4;
+use Test::More      tests => 5;
 
 use t::Util;
 
@@ -20,19 +20,19 @@ for my $test (
   {
     name   => 'default',
     config => simple_ini('Git::GatherDir'),
-    files  => [ qw(lib/DZT/Sample.pm tracked) ],
+    files  => [ qw(lib/DZT/Sample.pm share/tracked tracked) ],
 
   },
   {
     name   => 'include_dotfiles',
     config => simple_ini([ 'Git::GatherDir', { include_dotfiles => 1 } ]),
-    files  => [ qw(.gitignore .tracked lib/DZT/Sample.pm tracked) ],
+    files  => [ qw(.gitignore .tracked lib/DZT/Sample.pm share/tracked tracked) ],
   },
   {
     name   => 'include_untracked',
     min_git=> '1.5.4',
     config => simple_ini([ 'Git::GatherDir', { include_untracked => 1 } ]),
-    files  => [ qw(dist.ini lib/DZT/Sample.pm tracked untracked) ],
+    files  => [ qw(dist.ini lib/DZT/Sample.pm  share/tracked tracked untracked) ],
 
   },
   {
@@ -41,7 +41,13 @@ for my $test (
     config => simple_ini([ 'Git::GatherDir',
                            { include_dotfiles => 1, include_untracked => 1 } ]),
     files  => [ qw(.gitignore .tracked .untracked dist.ini lib/DZT/Sample.pm
-                   tracked untracked) ],
+                   share/tracked tracked untracked) ],
+  },
+  {
+    name   => 'exclude_filename',
+    config => simple_ini([ 'Git::GatherDir', { exclude_filename => 'tracked' } ]),
+    files  => [ qw(lib/DZT/Sample.pm share/tracked) ],
+
   },
 ) {
  SKIP: {
@@ -54,6 +60,7 @@ for my $test (
           'source/ignored'    => "This is ignored.\n",
           'source/untracked'  => "This is not tracked.\n",
           'source/tracked'    => "This is tracked.\n",
+          'source/share/tracked' => "This is tracked, in a subdir.\n",
           'source/.tracked'   => "This is a tracked dotfile.\n",
           'source/.ignored'   => "This is an ignored dotfile.\n",
           'source/.untracked' => "This is an untracked dotfile.\n",
@@ -74,7 +81,7 @@ for my $test (
     # check in tracked files
     # we cannot ship it in the dist, since PruneCruft plugin would trim it
     #   Don't use --force, because only -f works before git 1.5.6
-    $git->add( -f => qw(lib tracked .tracked .gitignore) );
+    $git->add( -f => qw(lib share tracked .tracked .gitignore) );
     $git->commit( { message=>'files known to git' } );
 
     $tzil->build;


### PR DESCRIPTION
My pluginbundle now has a share/CONTRIBUTING file, which eventually results in a CONTRIBUTING file being dropped into the root of the dist being built. My bundle does:

```
[Git::GatherDir]
exclude_filename = CONTRIBUTING
```

to ignore the version already there, to allow it to be regenerated.  But this rule stopped the gathering of the share/ file itself -- because [Git::GatherDir] wraps `\b` around the provided string, and then performs a regex match. This isn't the same as a literal string comparison, which is what [GatherDir] does.

This patch makes [Git::GatherDir] work like [GatherDir] again. Included are tests that demonstrate the fix.

(was also filed as https://github.com/rjbs/dist-zilla-plugin-git/pull/2)
