### PR TITLE
Class::MOP::load_class is deprecated; Module::Runtime is less hacky anyway

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,9 +1,10 @@
 Revision history for Dist::Zilla::Plugin::Git
 
 {{$NEXT}}
+ - remove use of deprecated Class::MOP function (Karen Etheridge)
 
 2.016     2013-10-19 18:27:32 Europe/Paris
- - fix exclude_filename to not match partial paths (karen etheridge)
+ - fix exclude_filename to not match partial paths (Karen Etheridge)
    If you really intended to match a partial path, use exclude_match instead.
  - documentation typo fixed in Git::NextVersion (david steinbrunner)
 

--- a/lib/Dist/Zilla/PluginBundle/Git.pm
+++ b/lib/Dist/Zilla/PluginBundle/Git.pm
@@ -6,7 +6,7 @@ package Dist::Zilla::PluginBundle::Git;
 # ABSTRACT: all git plugins in one go
 
 use Moose;
-use Class::MOP;
+use Module::Runtime 'use_module';
 
 with 'Dist::Zilla::Role::PluginBundle';
 
@@ -16,7 +16,7 @@ my @names   = qw{ Check Commit Tag Push };
 my %multi;
 for my $name (@names) {
     my $class = "Dist::Zilla::Plugin::Git::$name";
-    Class::MOP::load_class($class);
+    use_module $class;
     @multi{$class->mvp_multivalue_args} = ();
 }
 


### PR DESCRIPTION
The new Moose dev release tickles this issue.
