### PR TITLE
signal that ChainSmoking is broken in 1.04 and earlier with this release

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -13,6 +13,10 @@ x_MailingList = http://www.listbox.com/subscribe/?list_id=139292
 directory = corpus
 directory = t
 
+[Breaks]
+Dist::Zilla::App::CommandHelper::ChainSmoking = <= 1.04
+[Test::CheckBreaks]
+
 [Bootstrap::lib]
 [@Filter / JQ]
 -bundle  = @Author::JQUELIN


### PR DESCRIPTION
When 2.022 was released, ChainSmoking broke because it was applying roles to classes that weren't plugins (so the dump_config method wasn't available for wrapping). So, record the breakage in metadata (Dist::Zilla::App::CommandHelper::ChainSmoking up to and including 1.04 are broken by Dist-Zilla-Plugin-Git), and add a (never-failing) test that will check this metadata and noisily tell the user to update their module.

...as seen in http://www.cpantesters.org/cpan/report/1beddd16-cb7a-11e3-aef5-bf0ae0bfc7aa (and many other reports)
