### PR TITLE
remove the use of autobox

### DIFF
--- a/lib/Dist/Zilla/Plugin/Git/GatherDir.pm
+++ b/lib/Dist/Zilla/Plugin/Git/GatherDir.pm
@@ -3,7 +3,6 @@ package Dist::Zilla::Plugin::Git::GatherDir;
 
 
 use Moose;
-use Moose::Autobox;
 use MooseX::Types::Path::Tiny qw(Path);
 extends 'Dist::Zilla::Plugin::GatherDir' => { -version => 4.200016 }; # exclude_match
 with 'Dist::Zilla::Role::Git::Repo';
@@ -141,9 +140,9 @@ override gather_files => sub {
 
   my $exclude_regex = qr/\000/;
   $exclude_regex = qr/$exclude_regex|$_/
-    for ($self->exclude_match->flatten);
+    for (@{ $self->exclude_match });
 
-  my %is_excluded = map {; $_ => 1 } $self->exclude_filename->flatten;
+  my %is_excluded = map {; $_ => 1 } @{ $self->exclude_filename };
 
   my @files;
   FILE: for my $filename (uniq $git->ls_files(@opts)) {

--- a/lib/Dist/Zilla/Role/Git/DirtyFiles.pm
+++ b/lib/Dist/Zilla/Role/Git/DirtyFiles.pm
@@ -7,7 +7,6 @@ package Dist::Zilla::Role::Git::DirtyFiles;
 
 
 use Moose::Role;
-use Moose::Autobox;
 use MooseX::Types::Moose qw{ Any ArrayRef Str RegexpRef };
 use MooseX::Types::Path::Tiny 0.010 qw{ Paths to_Paths };
 use Moose::Util::TypeConstraints;
@@ -119,7 +118,7 @@ sub list_dirty_files
   my ($self, $git, $listAllowed) = @_;
 
   my $git_root  = $self->repo_root;
-  my @filenames = $self->allow_dirty->flatten;
+  my @filenames = @{ $self->allow_dirty };
 
   if ($git_root ne '.') {
     # Interpret allow_dirty relative to the dzil root
@@ -142,7 +141,7 @@ sub list_dirty_files
     }
   } # end if git root ne dzil root
 
-  my $allowed = join '|', $self->allow_dirty_match->flatten, map { qr{^\Q$_\E$} } @filenames;
+  my $allowed = join '|', @{ $self->allow_dirty_match }, map { qr{^\Q$_\E$} } @filenames;
 
   $allowed = qr/(?!X)X/ if $allowed eq ''; # this cannot match anything
 

--- a/t/lib/Dist/Zilla/Plugin/MyTestArchiver.pm
+++ b/t/lib/Dist/Zilla/Plugin/MyTestArchiver.pm
@@ -1,7 +1,6 @@
 # taken from DZP::ArchiveRelease, thanks CJM!
 package Dist::Zilla::Plugin::MyTestArchiver;
 use Moose;
-use Moose::Autobox;
 use Path::Tiny qw(path);
 use File::Copy ();
 


### PR DESCRIPTION
...as has been done for Dist-Zilla itself and in progress in various plugins (and also, autobox.pm doesn't install on 5.21.7)
