### PR TITLE
Specify current branch if no branch specified

### DIFF
--- a/lib/Dist/Zilla/Plugin/Git/Push.pm
+++ b/lib/Dist/Zilla/Plugin/Git/Push.pm
@@ -77,10 +77,15 @@ sub after_release {
     my $self = shift;
     my $git  = $self->git;
 
+    my ($branch) = $git->RUN(qw(rev-parse --abbrev-ref HEAD))
+        or $self->log_fatal("Could not determine current branch to push");
+
     # push everything on remote branch
     for my $remote ( @{ $self->push_to } ) {
       $self->log("pushing to $remote");
       my @remote = split(/\s+/,$remote);
+      push @remote, $branch if @remote == 1;
+
       $self->log_debug($_) for $git->push( @remote );
       $self->log_debug($_) for $git->push( { tags=>1 },  $remote[0] );
     }


### PR DESCRIPTION
Git's default behaviour has changed

    [Git::Push] pushing to origin
    fatal: You didn't specify any refspecs to push, and push.default is "nothing".

The docs for this plugin say it pushes the current branch, but that is a side-effect of what git used to do when you didn't specify a branch.

This patch will use the current branch explicitly if nothing else is specified in the `to_push` spec.