### PR TITLE
ensure _source_branch is never a tag

### DIFF
--- a/lib/Dist/Zilla/Plugin/Git/CommitBuild.pm
+++ b/lib/Dist/Zilla/Plugin/Git/CommitBuild.pm
@@ -61,7 +61,7 @@ has _source_branch => (
     lazy    => 1,
     init_arg=> undef,
     default => sub {
-        ($_[0]->git->name_rev( '--name-only', 'HEAD' ))[0];
+        ($_[0]->git->name_rev( '--name-only', '--refs=refs/heads/*', 'HEAD' ))[0];
     },
 );
 


### PR DESCRIPTION
If you're releasing to the CPAN where your HEAD is also tagged,
_source_branch's default would populate the attribute with the tag name.  This
is sub-optimal, and tends to result in things like:

    fatal: update_ref failed for ref 'refs/heads/build/tags/0.006^0': refusing to update ref with bad name 'refs/heads/build/tags/0.006^0'

The fix is to constrain the set of refs name-rev uses to name a commit
to the set of branches.

...why would we ever do this?  Well, imagine a situation where a TRIAL/dev
release has been cut and deemed satisfactory; it's possible a release would be
cut directly, without any changes from the previous release.